### PR TITLE
Align variable names for `glue_job` module.

### DIFF
--- a/modules/glue_job/main.tf
+++ b/modules/glue_job/main.tf
@@ -9,8 +9,8 @@ resource "aws_glue_job" "glue_job" {
   }
 
   default_arguments = {
-    "--job-language" = var.job-language
-    "--TempDir"      = var.TempDir
+    "--job-language" = var.job_language
+    "--TempDir"      = var.temp_dir
   }
 
   connections = var.connections

--- a/modules/glue_job/variables.tf
+++ b/modules/glue_job/variables.tf
@@ -20,11 +20,11 @@ variable "script_location" {
   type = string
 }
 
-variable "job-language" {
+variable "job_language" {
   type = string
 }
 
-variable "TempDir" {
+variable "temp_dir" {
   type = string
 }
 


### PR DESCRIPTION
Use `underscore` notation everywhere.