### PR TITLE
Remove `module_variable_optional_attrs` experiment

### DIFF
--- a/modules/kms_service_key/main.tf
+++ b/modules/kms_service_key/main.tf
@@ -2,10 +2,6 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 locals {
   default_statements = [
     {


### PR DESCRIPTION
Because of:
```
│ Error: Experiment has concluded
│
│   on .terraform/modules/service_key/modules/kms_service_key/main.tf line 6, in terraform:
│    6:   experiments = [module_variable_optional_attrs]
│
│ Experiment "module_variable_optional_attrs" is no longer available. The
│ final feature corresponding to this experiment differs from the
│ experimental form and is available in the Terraform language from Terraform
│ v1.3.0 onwards.
```